### PR TITLE
Imu optimized

### DIFF
--- a/config.env
+++ b/config.env
@@ -20,5 +20,5 @@ REFRESH_DELAY = 0.1 # how often to refresh/check for data in seconds
 
 # C++ struct formats
 TEMPERATURE_FORMAT = "f"
-IMU_FORMAT = "fffffff"
+IMU_FORMAT = "fffff"
 GNSS_FORMAT = "ff"

--- a/mqtt/handlers.py
+++ b/mqtt/handlers.py
@@ -14,10 +14,8 @@ def handle_imu(payload: bytes):
         "roll": floats[0],
         "pitch": floats[1],
         "yaw": floats[2],
-        "battery_temp": floats[3],
-        "power": floats[4],
-        "heading_deg": floats[5],
-        "speed": floats[6],
+        "heading_deg": floats[3],
+        "speed": floats[4],
     }
     return imu_data
 

--- a/pages/Telemetry_Page.py
+++ b/pages/Telemetry_Page.py
@@ -30,8 +30,6 @@ def main():
             "roll": 0.0,
             "pitch": 0.0,
             "yaw": 0.0,
-            "battery_temp": 0.0,
-            "power": 0.0,
             "heading_deg": 0.0,
             "speed": 0.0,
         }

--- a/sections/map.py
+++ b/sections/map.py
@@ -160,8 +160,7 @@ def display():
             "heading": 0,
             "pitch": 0,
             "roll": 0,
-            "battery_temp": 0,
-            "power": 0,
+            "yaw": 0,
         }
     if "pois" not in st.session_state:
         st.session_state.pois = []

--- a/sections/map.py
+++ b/sections/map.py
@@ -145,9 +145,9 @@ def _map_updater():
 @st.fragment(run_every=f"{REFRESH_DELAY}s")
 def _coords_display(lat_col, long_col):
     with lat_col:
-        st.write(f"LAT: {st.session_state.gnss_data['latitude']}")
+        st.write(f"LAT: {st.session_state.gnss_data['latitude']:.6f}")
     with long_col:
-        st.write(f"LONG: {st.session_state.gnss_data['longitude']}")
+        st.write(f"LONG: {st.session_state.gnss_data['longitude']:.6f}")
 
 
 def display():

--- a/sections/rover.py
+++ b/sections/rover.py
@@ -48,8 +48,8 @@ def update_telemetry():
         unsafe_allow_html=True,
     )
 
-    pitch_col, roll_col, wheels_col, arm_col, power_col = st.columns(
-        5, vertical_alignment="center"
+    pitch_col, roll_col, wheels_col, arm_col = st.columns(
+        4, vertical_alignment="center"
     )
 
     with pitch_col:
@@ -76,21 +76,21 @@ def update_telemetry():
         with st.container(key="rover-arm-text"):
             st.markdown("Arm")
 
-    with power_col:
-        st.metric(
-            label="Battery Temp",
-            value="%0.2f°C" % st.session_state.imu_data["battery_temp"],
-        )
-        st.metric(label="Power", value="%0.2f%%" % st.session_state.imu_data["power"])
+    # with power_col:
+    #     st.metric(
+    #         label="Battery Temp",
+    #         value="%0.2f°C" % st.session_state.imu_data["battery_temp"],
+    #     )
+    #     st.metric(label="Power", value="%0.2f%%" % st.session_state.imu_data["power"])
 
-        # with st.container(key="battery-temp-text"):
-        #     st.markdown("Battery Temperature")
-        # with st.container(key="battery-temp"):
-        #     st.markdown("%0.2f°C" % st.session_state.imu_data["battery_temp"])
-        # with st.container(key="power-text"):
-        #     st.markdown("Power")
-        # with st.container(key="power"):
-        #    st.markdown("%0.2f%%" % st.session_state.imu_data["power"])
+    # with st.container(key="battery-temp-text"):
+    #     st.markdown("Battery Temperature")
+    # with st.container(key="battery-temp"):
+    #     st.markdown("%0.2f°C" % st.session_state.imu_data["battery_temp"])
+    # with st.container(key="power-text"):
+    #     st.markdown("Power")
+    # with st.container(key="power"):
+    #    st.markdown("%0.2f%%" % st.session_state.imu_data["power"])
 
 
 def display():

--- a/static/styles/telemetry_styles.css
+++ b/static/styles/telemetry_styles.css
@@ -122,7 +122,7 @@ div[data-testid="stImage"] img {
     width: 100% !important;
 }
 
-.st-key-battery-temp-text [data-testid="stMarkdownContainer"] p {
+/* .st-key-battery-temp-text [data-testid="stMarkdownContainer"] p {
     text-align: center;
     font-size: 1.2rem;
     font-weight: bold;
@@ -160,7 +160,7 @@ div[data-testid="stImage"] img {
 
     margin-top: -15%;
     padding-bottom: 0px;
-}
+} */
 
 div[data-testid="stImage"] img {
     width: 100%;


### PR DESCRIPTION
# Task
Closes #61 

https://github.com/ucalgary-rover/SSRT-Telemetry/issues/61 

# Description
Removed battery temp and power from code. So it no longer expects those fields from the back end. Fixed it to expect 20 bytes instead of 28. Removed unneeded battery temp and power fields from the IMU section of the telemetry

# Fixes
Also edited latitude and longitude in map section to only display 6 decimals. Makes it clearer and less cluttered